### PR TITLE
Add class variable USE_UNIQUE_DUPLICATE_SUFFIX

### DIFF
--- a/model_clone/mixins/clone.py
+++ b/model_clone/mixins/clone.py
@@ -76,7 +76,7 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
                         .filter(**{'{}__startswith'.format(f.attname): value})
                         .count()
                     )
-                    if cls.USE_UNIQUE_DUPLICATE_SUFFIX is True:
+                    if cls.USE_UNIQUE_DUPLICATE_SUFFIX:
                         if not str(value).isdigit():
                             value += ' {} {}'.format(cls.UNIQUE_DUPLICATE_SUFFIX, count)
                     if isinstance(f, SlugField):

--- a/model_clone/mixins/clone.py
+++ b/model_clone/mixins/clone.py
@@ -37,6 +37,7 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
     _clonable_one_to_one_fields = []
 
     UNIQUE_DUPLICATE_SUFFIX = 'copy'
+    USE_UNIQUE_DUPLICATE_SUFFIX = True
 
     @property
     @abc.abstractmethod
@@ -75,8 +76,9 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
                         .filter(**{'{}__startswith'.format(f.attname): value})
                         .count()
                     )
-                    if not str(value).isdigit():
-                        value += ' {} {}'.format(cls.UNIQUE_DUPLICATE_SUFFIX, count)
+                    if cls.USE_UNIQUE_DUPLICATE_SUFFIX is True:
+                        if not str(value).isdigit():
+                            value += ' {} {}'.format(cls.UNIQUE_DUPLICATE_SUFFIX, count)
                     if isinstance(f, SlugField):
                         value = slugify(value)
                 defaults[f.attname] = value


### PR DESCRIPTION
Hello, I have the following use case:

a) I have an object with a string field (uuid) that is stored in a 36 character field.
b) I want to use django-clone to create copies of it (including the uuid), however the current implementation append the UNIQUE_DUPLICATE_SUFFIX field and hence the value is larger than the max field size and the save() call fails.

This PR adds a class variable `USE_UNIQUE_DUPLICATE_SUFFIX` to disable this behavior.