### PR TITLE
Handle case when value in unquie field has fields max_length

### DIFF
--- a/model_clone/mixins/clone.py
+++ b/model_clone/mixins/clone.py
@@ -82,6 +82,8 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
     _clone_excluded_one_to_one_fields = []
 
     UNIQUE_DUPLICATE_SUFFIX = 'copy'
+    # 1 for space, 4 for copy, 1 for space, 2 for count  == ' copy 33'
+    UNIQUE_DUPLICATE_LENGTH = 8
     USE_UNIQUE_DUPLICATE_SUFFIX = True
 
     @classmethod
@@ -128,6 +130,8 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
                         .count()
                     )
                     if cls.USE_UNIQUE_DUPLICATE_SUFFIX:
+                        if len(value) + cls.UNIQUE_DUPLICATE_LENGTH > f.max_length:
+                            value = value[: f.max_length - cls.UNIQUE_DUPLICATE_LENGTH]
                         if not str(value).isdigit():
                             value += ' {} {}'.format(
                                 cls.UNIQUE_DUPLICATE_SUFFIX, count)

--- a/model_clone/tests.py
+++ b/model_clone/tests.py
@@ -183,3 +183,33 @@ class CloneMixinTestCase(TestCase):
             author_clone.first_name,
             '{} {} {}'.format(first_name, 'new', 1),
         )
+
+    def test_cloning_unique_fields_max_length(self):
+        """Max unique field length handling
+
+        Set the initial value for the unique field to max length
+        and test to append the [ copy count]
+        """
+        first_name = (
+            'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, '
+            'sed diam nonumy eirmod tempor invidunt ut labore et dolore '
+            'magna aliquyam erat, sed diam voluptua. At vero eos et accusam '
+            'et justo duo dolores '
+        )
+        author = Author.objects.create(
+            first_name=first_name,
+            last_name='Jack',
+            age=26,
+            sex='F',
+            created_by=self.user
+        )
+
+        author_clone = author.make_clone()
+
+        # clone slices 8 chars of but count uses only 1 digit.
+        self.assertEqual(len(author_clone.first_name), 199)
+        self.assertNotEqual(author.pk, author_clone.pk)
+        self.assertEqual(
+            author_clone.first_name,
+            '{} {} {}'.format(first_name[:192], Author.UNIQUE_DUPLICATE_SUFFIX, 1),
+        )


### PR DESCRIPTION
I had a problem with the max length of a unique field to copy. So here comes my suggestion for how to handle this edge case.

Since it's a clone the original value still exists. To stay in the fields max_length requirement I suggest cutting off the number of character that will be appended. I figured that the required number for this is 8 (1 for space, 4 for copy, 1 for space, 2 for count)(example = ' copy 33')

Also, added test to see if my fix actually works.